### PR TITLE
Send unset catchupWindow in schedules if not specified (Test PR)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -161,11 +161,13 @@ public class ScheduleProtoUtil {
   }
 
   public SchedulePolicies policyToProto(SchedulePolicy policy) {
-    return SchedulePolicies.newBuilder()
-        .setCatchupWindow(ProtobufTimeUtils.toProtoDuration(policy.getCatchupWindow()))
-        .setPauseOnFailure(policy.isPauseOnFailure())
-        .setOverlapPolicy(policy.getOverlap())
-        .build();
+    SchedulePolicies.Builder builder = SchedulePolicies.newBuilder();
+    if (policy.getCatchupWindow() != null) {
+      builder.setCatchupWindow(ProtobufTimeUtils.toProtoDuration(policy.getCatchupWindow()));
+    }
+    builder.setPauseOnFailure(policy.isPauseOnFailure());
+    builder.setOverlapPolicy(policy.getOverlap());
+    return builder.build();
   }
 
   public List<Range> scheduleRangeToProto(List<ScheduleRange> scheduleRanges) {


### PR DESCRIPTION
If the catchupWindow property was not set in SchedulePolicy, it was sent as a zero duration in the appropriate protobuf message. However, the server expects an unset value here. The previous behavior led to setting the actual catchupWindow on the server to the minimal value (10 seconds) instead of the default (1 year).